### PR TITLE
hydro: Make Content.permissions repeated

### DIFF
--- a/latest/proto/hydro/v1/resources.proto
+++ b/latest/proto/hydro/v1/resources.proto
@@ -16,7 +16,7 @@ message Content {
 	
 	string name = 1;
 	string user = 2;
-	ContentPermission permissions = 3;
+	repeated ContentPermission permissions = 3;
 	google.protobuf.Timestamp create_time = 4;
 	google.protobuf.Timestamp update_time = 5;
 	bytes payload = 6;


### PR DESCRIPTION
As seen in some Pokemon Arceus dumps, this is actually a wire LEN type meaning it must be repeated.